### PR TITLE
Added an explicit test for the subpattern POSTFIX_RELAY_INFO that is use...

### DIFF
--- a/test/relay_info_0001.yaml
+++ b/test/relay_info_0001.yaml
@@ -1,0 +1,6 @@
+# this data is derived after the keyvalue data is expanded in logstash to a 'postfix_relay_info' field.
+pattern: POSTFIX_RELAY_INFO
+data: "1.example.com.si[private/dovecot-lmtp]"
+results:
+    postfix_relay_hostname: 1.example.com.si
+    postfix_relay_service: private/dovecot-lmtp


### PR DESCRIPTION
...d after expanding the keyvalue data