### PR TITLE
postfix patterns for pypolicyd-spf

### DIFF
--- a/50-filter-postfix.conf
+++ b/50-filter-postfix.conf
@@ -140,6 +140,13 @@ filter {
             tag_on_failure => [ "_grok_postfix_discard_nomatch" ]
             add_tag        => [ "_grok_postfix_success" ]
         }
+    } else if [postfix_stage] =~ /^policyd-spf$/ {
+        grok {
+            patterns_dir   => "/etc/logstash/patterns.d"
+            match          => [ "message", "%{POSTFIX_POLICYD_SPF}" ]
+            tag_on_failure => [ "_grok_postfix_discard_nomatch" ]
+            add_tag        => [ "_grok_postfix_success" ]
+        }
     }
 
     # process key-value data is it exists

--- a/postfix.grok
+++ b/postfix.grok
@@ -81,6 +81,10 @@ POSTFIX_SCACHE_LOOKUPS statistics: (address|domain) lookup hits=%{INT:postfix_sc
 POSTFIX_SCACHE_SIMULTANEOUS statistics: max simultaneous domains=%{INT:postfix_scache_domains} addresses=%{INT:postfix_scache_addresses} connection=%{INT:postfix_scache_connection}
 POSTFIX_SCACHE_TIMESTAMP statistics: start interval %{SYSLOGTIMESTAMP:postfix_scache_timestamp}
 
+# check stage of postfix
+POSTFIX_STAGE_VALUE (postfix\/[a-zA-Z]+|policyd-spf)
+POSTFIX_STAGE %{POSTFIX_STAGE_VALUE:postfix_stage}
+
 # aggregate all patterns
 POSTFIX_SMTPD %{POSTFIX_SMTPD_CONNECT}|%{POSTFIX_SMTPD_DISCONNECT}|%{POSTFIX_SMTPD_LOSTCONN}|%{POSTFIX_SMTPD_NOQUEUE}|%{POSTFIX_SMTPD_PIPELINING}|%{POSTFIX_TLSCONN}|%{POSTFIX_WARNING}|%{POSTFIX_SMTPD_PROXY}|%{POSTFIX_KEYVALUE}
 POSTFIX_CLEANUP %{POSTFIX_CLEANUP_MILTER}|%{POSTFIX_WARNING}|%{POSTFIX_KEYVALUE}

--- a/postfix.grok
+++ b/postfix.grok
@@ -85,6 +85,13 @@ POSTFIX_SCACHE_TIMESTAMP statistics: start interval %{SYSLOGTIMESTAMP:postfix_sc
 POSTFIX_STAGE_VALUE (postfix\/[a-zA-Z]+|policyd-spf)
 POSTFIX_STAGE %{POSTFIX_STAGE_VALUE:postfix_stage}
 
+# policyd spf (https://launchpad.net/pypolicyd-spf/)
+POSTFIX_POLICYD_SPF_EMAIL_FROM %{EMAIL_ADDRESS_USER:postfix_policyd_from_email_user}@%{EMAIL_ADDRESS_DOMAIN:postfix_policyd_spf_from_email_domain}
+POSTFIX_POLICYD_SPF_EMAIL_TO %{EMAIL_ADDRESS_USER:postfix_policyd_to_email_user}@%{EMAIL_ADDRESS_DOMAIN:postfix_policyd_spf_to_email_domain}
+POSTFIX_POLICYD_SPF_STATUS_CODE (Pass|Fail|None|Neutral|Softfail|Temperror|Permerror)
+POSTFIX_POLICYD_SPF_IDENTITY (helo|mailfrom)
+POSTFIX_POLICYD_SPF %{POSTFIX_POLICYD_SPF_STATUS_CODE:postfix_policyd_spf_result}; identity=%{POSTFIX_POLICYD_SPF_IDENTITY:postfix_policyd_spf_identity}; client-ip=%{IP:postfix_policyd_spf_client_ip}; helo=%{HOST:postfix_policyd_spf_helo}; envelope-from=%{POSTFIX_POLICYD_SPF_EMAIL_FROM}; receiver=%{POSTFIX_POLICYD_SPF_EMAIL_TO}
+
 # aggregate all patterns
 POSTFIX_SMTPD %{POSTFIX_SMTPD_CONNECT}|%{POSTFIX_SMTPD_DISCONNECT}|%{POSTFIX_SMTPD_LOSTCONN}|%{POSTFIX_SMTPD_NOQUEUE}|%{POSTFIX_SMTPD_PIPELINING}|%{POSTFIX_TLSCONN}|%{POSTFIX_WARNING}|%{POSTFIX_SMTPD_PROXY}|%{POSTFIX_KEYVALUE}
 POSTFIX_CLEANUP %{POSTFIX_CLEANUP_MILTER}|%{POSTFIX_WARNING}|%{POSTFIX_KEYVALUE}

--- a/postfix.grok
+++ b/postfix.grok
@@ -1,3 +1,8 @@
+# Email pattern (https://tools.ietf.org/html/rfc3696)
+EMAIL_ADDRESS_USER [a-zA-Z0-9!#$%&'*+-/=?^_`.{|}~]+
+EMAIL_ADDRESS_DOMAIN [a-zA-Z0-9.-]+
+EMAIL_ADDRESS %{EMAIL_ADDRESS_USER:postfix_email_user}@%{EMAIL_ADDRESS_DOMAIN:postfix_email_domain}
+
 # common postfix patterns
 POSTFIX_QUEUEID ([0-9A-F]{6,}|[0-9a-zA-Z]{15,}|NOQUEUE)
 POSTFIX_CLIENT_INFO %{HOST:postfix_client_hostname}?\[%{IP:postfix_client_ip}\](:%{INT:postfix_client_port})?


### PR DESCRIPTION
Added support for pypolicyd-spf (https://launchpad.net/pypolicyd-spf/)
Added email address parsing for username and domain
Added grok pattern to find stage of postfix if not using condition of program
ex:

filter {
        grok {
            patterns_dir   => "/etc/logstash/patterns.d"
            match          => [ "message", "%{POSTFIX_STAGE}" ]
            tag_on_failure => [ "_grok_postfix_stage_nomatch" ]
            add_tag        => [ "_grok_postfix_stage_success" ]
        }

    # grok log lines by program name (listed alpabetically)
    if [postfix_stage] =~ /^postfix.*\/anvil$/ {
        grok {
            patterns_dir   => "/etc/logstash/patterns.d"
            match          => [ "message", "%{POSTFIX_ANVIL}" ]
            tag_on_failure => [ "_grok_postfix_anvil_nomatch" ]
            add_tag        => [ "_grok_postfix_success" ]
        }
    }

Examples from my mail logs for the output of pypolicyd-spf

Aug 17 10:08:05 test policyd-spf[21135]: Pass; identity=helo; client-ip=2.4.6.8; helo=helo1.example.com; envelope-from=jsmith@example.com; receiver=bsmith@example.com
Aug 17 10:08:05 test policyd-spf[21135]: Fail; identity=mailfrom; client-ip=2.4.6.8; helo=helo1.example.com; envelope-from=jsmith@example.com; receiver=bsmith@example.com
Aug 17 10:08:10 test policyd-spf[21135]: Pass; identity=helo; client-ip=2.4.6.8; helo=helo2.example.com; envelope-from=csmith@example.com; receiver=dsmith@example.com
Aug 17 10:08:11 test policyd-spf[21135]: Pass; identity=mailfrom; client-ip=2.4.6.8; helo=helo2.example.com; envelope-from=csmith@example.com; receiver=dsmith@example.com