### PR TITLE
Fix postfix_warning pattern, solves #84

### DIFF
--- a/postfix.grok
+++ b/postfix.grok
@@ -11,7 +11,7 @@ POSTFIX_PS_ACCESS_ACTION (DISCONNECT|BLACKLISTED|WHITELISTED|WHITELIST VETO|PASS
 POSTFIX_PS_VIOLATION (BARE NEWLINE|COMMAND (TIME|COUNT|LENGTH) LIMIT|COMMAND PIPELINING|DNSBL|HANGUP|NON-SMTP COMMAND|PREGREET)
 POSTFIX_TIME_UNIT %{NUMBER}[smhd]
 POSTFIX_KEYVALUE %{POSTFIX_QUEUEID:postfix_queueid}: %{GREEDYDATA:postfix_keyvalue_data}
-POSTFIX_WARNING (warning|fatal): %{GREEDYDATA:postfix_warning}
+POSTFIX_WARNING (%{POSTFIX_QUEUEID:postfix_queueid}: )?(warning|fatal): %{GREEDYDATA_NO_SEMICOLON:postfix_warning}(; %{GREEDYDATA:postfix_keyvalue_data})?
 POSTFIX_TLSCONN (Anonymous|Trusted|Untrusted|Verified) TLS connection established (to %{POSTFIX_RELAY_INFO}|from %{POSTFIX_CLIENT_INFO}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \(%{DATA:postfix_tls_cipher_size} bits\)
 POSTFIX_DELAYS %{NUMBER:postfix_delay_before_qmgr}/%{NUMBER:postfix_delay_in_qmgr}/%{NUMBER:postfix_delay_conn_setup}/%{NUMBER:postfix_delay_transmission}
 POSTFIX_LOSTCONN (lost connection|timeout|SSL_accept error)
@@ -19,6 +19,7 @@ POSTFIX_PROXY_MESSAGE (%{POSTFIX_STATUS_CODE:postfix_proxy_status_code} )?(%{POS
 
 # helper patterns
 GREEDYDATA_NO_COLON [^:]*
+GREEDYDATA_NO_SEMICOLON [^;]*
 
 # smtpd patterns
 POSTFIX_SMTPD_CONNECT connect from %{POSTFIX_CLIENT_INFO}

--- a/test/cleanup_0006.yaml
+++ b/test/cleanup_0006.yaml
@@ -1,0 +1,6 @@
+pattern: POSTFIX_CLEANUP
+data: "D8B07E3DB6: warning: header Subject: https://drive.google.com/file/d/0B8wxcvprDYVdlVsdf1kzOVkdisarmed/view?usp=sharing from o1678917x173.outbound-mail.sendgrid.net[167.89.17.173]; from=<bounces+2320708-7653-frank.test=hsdjasdd.co.uk@sendgrid.net> to=<frank.test@hsdjasdd.co.uk> proto=ESMTP helo=<o1678917x173.outbound-mail.sendgrid.net>"
+results:
+    postfix_queueid: D8B07E3DB6
+    postfix_warning: "header Subject: https://drive.google.com/file/d/0B8wxcvprDYVdlVsdf1kzOVkdisarmed/view?usp=sharing from o1678917x173.outbound-mail.sendgrid.net[167.89.17.173]"
+    postfix_keyvalue_data: "from=<bounces+2320708-7653-frank.test=hsdjasdd.co.uk@sendgrid.net> to=<frank.test@hsdjasdd.co.uk> proto=ESMTP helo=<o1678917x173.outbound-mail.sendgrid.net>"

--- a/test/smtp_0026.yaml
+++ b/test/smtp_0026.yaml
@@ -1,0 +1,7 @@
+pattern: POSTFIX_SMTP
+data: "A0E85200BD: to=<whatever-user@lists.example.org>, relay=open.example.nl[10.49.140.10]:25, delay=2.3, delays=0.25/0.05/2/0.04, dsn=4.2.0, status=deferred (host open.example.nl[10.49.140.10] said: 450 4.2.0 <whatever-user@lists.example.org>: Recipient address rejected: Greylisted, see http://postgrey.schweikert.ch/help/lists.example.org.html (in reply to RCPT TO command))"
+results:
+    postfix_queueid: A0E85200BD
+    postfix_keyvalue_data: "to=<whatever-user@lists.example.org>, relay=open.example.nl[10.49.140.10]:25, delay=2.3, delays=0.25/0.05/2/0.04, dsn=4.2.0,"
+    postfix_status: deferred
+    postfix_smtp_response: "host open.example.nl[10.49.140.10] said: 450 4.2.0 <whatever-user@lists.example.org>: Recipient address rejected: Greylisted, see http://postgrey.schweikert.ch/help/lists.example.org.html (in reply to RCPT TO command)"


### PR DESCRIPTION
The `POSTFIX_WARNING` pattern did not match any lines that start with a postfix queue id, which resulted in an attempt of the `POSTFIX_KEYVALUE` pattern to handle the line.

Because of the typical whitespace before a url in the warning message, and the `=` character in the query parameters, this made the key-value parser create a `postfix_http://example.org/something.html?arg` (or similar) fieldname, which is illegal syntax.

Solved by fixing the `POSTFIX_WARNING` pattern to pickup the lines correctly.