### PR TITLE
Logstash 4.0 support

### DIFF
--- a/50-filter-postfix.conf
+++ b/50-filter-postfix.conf
@@ -171,7 +171,7 @@ filter {
     if [postfix_keyvalue_data] {
         kv {
             source       => "postfix_keyvalue_data"
-            trim         => "<>,"
+            trim_value   => "<>,"
             prefix       => "postfix_"
             remove_field => [ "postfix_keyvalue_data" ]
         }


### PR DESCRIPTION
https://github.com/logstash-plugins/logstash-filter-kv/blob/master/CHANGELOG.md#400 
breaking: trim and trimkey options are renamed to trim_value and trim_key