### PR TITLE
Extract Client info from warning messages, when available

### DIFF
--- a/postfix.grok
+++ b/postfix.grok
@@ -29,8 +29,8 @@ GREEDYDATA_NO_SEMICOLON [^;]*
 STATUS_WORD [\w-]*
 
 # warning patterns
-POSTFIX_WARNING_WITH_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: %{GREEDYDATA:postfix_message}; %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}
-POSTFIX_WARNING_WITHOUT_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: %{GREEDYDATA:postfix_message}
+POSTFIX_WARNING_WITH_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: (%{POSTFIX_CLIENT_INFO}: )?%{GREEDYDATA:postfix_message}; %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}
+POSTFIX_WARNING_WITHOUT_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: (%{POSTFIX_CLIENT_INFO}: )?%{GREEDYDATA:postfix_message}
 POSTFIX_WARNING %{POSTFIX_WARNING_WITH_KV}|%{POSTFIX_WARNING_WITHOUT_KV}
 
 # smtpd patterns

--- a/test/smtpd_0029.yaml
+++ b/test/smtpd_0029.yaml
@@ -1,0 +1,6 @@
+pattern: ^%{POSTFIX_SMTPD}$
+data: "warning: ec2-3-84-57-208.compute-1.amazonaws.com[3.84.57.208]: SASL LOGIN authentication failed: UGFzc3dvcmQ6"
+results:
+    postfix_client_hostname: ec2-3-84-57-208.compute-1.amazonaws.com
+    postfix_client_ip: 3.84.57.208
+    postfix_message: "SASL LOGIN authentication failed: UGFzc3dvcmQ6"


### PR DESCRIPTION
This should provide 2 new logstash fields for warning messages, when they set the client info:
- postfix_client_hostname
- postfix_client_ip