### PR TITLE
Various pattern additions.

### DIFF
--- a/50-filter-postfix.conf
+++ b/50-filter-postfix.conf
@@ -175,6 +175,13 @@ filter {
             tag_on_failure => [ "_grok_postfix_script_nomatch" ]
             add_tag        => [ "_grok_postfix_success" ]
         }
+    } else if [program] =~ /^postfix.*\/verify$/ {
+        grok {
+            patterns_dir   => "/etc/logstash/patterns.d"
+            match          => [ "message", "^%{POSTFIX_VERIFY}$" ]
+            tag_on_failure => [ "_grok_postfix_verify_nomatch" ]
+            add_tag        => [ "_grok_postfix_success" ]
+        }
     } else if [program] =~ /^postfix.*/ {
         mutate {
             add_tag => [ "_grok_postfix_program_nomatch" ]
@@ -237,6 +244,8 @@ filter {
             "postfix_client_port", "integer",
             "postfix_cmd_auth", "integer",
             "postfix_cmd_auth_accepted", "integer",
+            "postfix_cmd_bdat", "integer",
+            "postfix_cmd_bdat_accepted", "integer",
             "postfix_cmd_count", "integer",
             "postfix_cmd_count_accepted", "integer",
             "postfix_cmd_data", "integer",
@@ -247,6 +256,8 @@ filter {
             "postfix_cmd_helo_accepted", "integer",
             "postfix_cmd_mail", "integer",
             "postfix_cmd_mail_accepted", "integer",
+            "postfix_cmd_noop", "integer",
+            "postfix_cmd_noop_accepted", "integer",
             "postfix_cmd_quit", "integer",
             "postfix_cmd_quit_accepted", "integer",
             "postfix_cmd_rcpt", "integer",
@@ -277,4 +288,3 @@ filter {
         ]
     }
 }
-

--- a/postfix.grok
+++ b/postfix.grok
@@ -2,9 +2,9 @@
 
 # common postfix patterns
 POSTFIX_QUEUEID ([0-9A-F]{6,}|[0-9a-zA-Z]{12,}|NOQUEUE)
-POSTFIX_CLIENT_INFO %{HOSTNAME:postfix_client_hostname}?\[%{IP:postfix_client_ip}\](:%{INT:postfix_client_port})?
+POSTFIX_CLIENT_INFO %{HOSTNAME:postfix_client_hostname}?\[(unknown|%{IP:postfix_client_ip})\](:%{INT:postfix_client_port})?
 POSTFIX_RELAY_INFO %{HOSTNAME:postfix_relay_hostname}?\[(%{IP:postfix_relay_ip}|%{DATA:postfix_relay_service})\](:%{INT:postfix_relay_port})?|%{WORD:postfix_relay_service}
-POSTFIX_SMTP_STAGE (CONNECT|HELO|EHLO|STARTTLS|AUTH|MAIL( FROM)?|RCPT( TO)?|(end of )?DATA|RSET|UNKNOWN|END-OF-MESSAGE|VRFY|\.)
+POSTFIX_SMTP_STAGE (CONNECT|HELO|EHLO|STARTTLS|AUTH|MAIL( FROM)?|RCPT( TO)?|(end of )?DATA|RSET|UNKNOWN|END-OF-MESSAGE|VRFY|\.|BDAT)
 POSTFIX_ACTION (accept|defer|discard|filter|header-redirect|reject|reject_warning)
 POSTFIX_STATUS_CODE \d{3}
 POSTFIX_STATUS_CODE_ENHANCED \d\.\d+\.\d+
@@ -20,10 +20,10 @@ POSTFIX_TLSCONN (Anonymous|Trusted|Untrusted|Verified) TLS connection establishe
 POSTFIX_TLSVERIFICATION certificate verification failed for %{POSTFIX_RELAY_INFO}: %{GREEDYDATA:postfix_tls_error}
 
 POSTFIX_DELAYS %{NUMBER:postfix_delay_before_qmgr}/%{NUMBER:postfix_delay_in_qmgr}/%{NUMBER:postfix_delay_conn_setup}/%{NUMBER:postfix_delay_transmission}
-POSTFIX_LOSTCONN (Connection timed out|No route to host|Connection refused|Network is unreachable|lost connection|timeout|SSL_accept error|-1)
-POSTFIX_LOSTCONN_REASONS (receiving the initial server greeting|sending message body|sending end of data -- message may be sent more than once)
+POSTFIX_LOSTCONN (Connection timed out|No route to host|Connection refused|Network is unreachable|lost connection|timeout|SSL_accept error|-1|Address not available|Operation timed out)
+POSTFIX_LOSTCONN_REASONS (receiving the initial server greeting|sending message body|sending end of data -- message may be sent more than once|sending %{POSTFIX_SMTP_STAGE:postfix_smtp_stage})
 POSTFIX_PROXY_MESSAGE (%{POSTFIX_STATUS_CODE:postfix_proxy_status_code} )?(%{POSTFIX_STATUS_CODE_ENHANCED:postfix_proxy_status_code_enhanced})?.*
-POSTFIX_COMMAND_COUNTER_DATA (helo=(%{INT:postfix_cmd_helo_accepted}/)?%{INT:postfix_cmd_helo} )?(ehlo=(%{INT:postfix_cmd_ehlo_accepted}/)?%{INT:postfix_cmd_ehlo} )?(starttls=(%{INT:postfix_cmd_starttls_accepted}/)?%{INT:postfix_cmd_starttls} )?(auth=(%{INT:postfix_cmd_auth_accepted}/)?%{INT:postfix_cmd_auth} )?(mail=(%{INT:postfix_cmd_mail_accepted}/)?%{INT:postfix_cmd_mail} )?(rcpt=(%{INT:postfix_cmd_rcpt_accepted}/)?%{INT:postfix_cmd_rcpt} )?(data=(%{INT:postfix_cmd_data_accepted}/)?%{INT:postfix_cmd_data} )?(rset=(%{INT:postfix_cmd_rset_accepted}/)?%{INT:postfix_cmd_rset} )?(quit=(%{INT:postfix_cmd_quit_accepted}/)?%{INT:postfix_cmd_quit} )?(unknown=(%{INT:postfix_cmd_unknown_accepted}/)?%{INT:postfix_cmd_unknown} )?commands=(%{INT:postfix_cmd_count_accepted}/)?%{INT:postfix_cmd_count}
+POSTFIX_COMMAND_COUNTER_DATA (helo=(%{INT:postfix_cmd_helo_accepted}/)?%{INT:postfix_cmd_helo} )?(ehlo=(%{INT:postfix_cmd_ehlo_accepted}/)?%{INT:postfix_cmd_ehlo} )?(starttls=(%{INT:postfix_cmd_starttls_accepted}/)?%{INT:postfix_cmd_starttls} )?(auth=(%{INT:postfix_cmd_auth_accepted}/)?%{INT:postfix_cmd_auth} )?(mail=(%{INT:postfix_cmd_mail_accepted}/)?%{INT:postfix_cmd_mail} )?(rcpt=(%{INT:postfix_cmd_rcpt_accepted}/)?%{INT:postfix_cmd_rcpt} )?(bdat=(%{INT:postfix_cmd_bdat_accepted}/)?%{INT:postfix_cmd_bdat} )?(data=(%{INT:postfix_cmd_data_accepted}/)?%{INT:postfix_cmd_data} )?(rset=(%{INT:postfix_cmd_rset_accepted}/)?%{INT:postfix_cmd_rset} )?(noop=(%{INT:postfix_cmd_noop_accepted}/)?%{INT:postfix_cmd_noop} )?(quit=(%{INT:postfix_cmd_quit_accepted}/)?%{INT:postfix_cmd_quit} )?(unknown=(%{INT:postfix_cmd_unknown_accepted}/)?%{INT:postfix_cmd_unknown} )?commands=(%{INT:postfix_cmd_count_accepted}/)?%{INT:postfix_cmd_count}
 
 # helper patterns
 GREEDYDATA_NO_COLON [^:]*
@@ -87,9 +87,9 @@ POSTFIX_DNSBLOG_LISTING addr %{IP:postfix_client_ip} listed by domain %{HOSTNAME
 POSTFIX_TLSPROXY_CONN (DIS)?CONNECT( from)? %{POSTFIX_CLIENT_INFO}
 
 # anvil patterns
-POSTFIX_ANVIL_CONN_RATE statistics: max connection rate %{NUMBER:postfix_anvil_conn_rate}/%{POSTFIX_TIME_UNIT:postfix_anvil_conn_period} for \(%{DATA:postfix_service}:%{IP:postfix_client_ip}\) at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}
+POSTFIX_ANVIL_CONN_RATE statistics: max connection rate %{NUMBER:postfix_anvil_conn_rate}/%{POSTFIX_TIME_UNIT:postfix_anvil_conn_period} for \(%{DATA:postfix_service}:(unknown|%{IP:postfix_client_ip})\) at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}
 POSTFIX_ANVIL_CONN_CACHE statistics: max cache size %{NUMBER:postfix_anvil_cache_size} at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}
-POSTFIX_ANVIL_CONN_COUNT statistics: max connection count %{NUMBER:postfix_anvil_conn_count} for \(%{DATA:postfix_service}:%{IP:postfix_client_ip}\) at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}
+POSTFIX_ANVIL_CONN_COUNT statistics: max connection count %{NUMBER:postfix_anvil_conn_count} for \(%{DATA:postfix_service}:(unknown|%{IP:postfix_client_ip})\) at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}
 
 # smtp patterns
 POSTFIX_SMTP_DELIVERY %{POSTFIX_KEYVALUE} status=%{STATUS_WORD:postfix_status}( \(%{GREEDYDATA:postfix_smtp_response}\))?
@@ -97,7 +97,7 @@ POSTFIX_SMTP_CONNERR connect to %{POSTFIX_RELAY_INFO}: %{POSTFIX_LOSTCONN:postfi
 POSTFIX_SMTP_SSLCONNERR SSL_connect error to %{POSTFIX_RELAY_INFO}: %{POSTFIX_LOSTCONN:postfix_smtp_lostconn_data}
 POSTFIX_SMTP_LOSTCONN %{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_LOSTCONN:postfix_smtp_lostconn_data} with %{POSTFIX_RELAY_INFO}( while %{POSTFIX_LOSTCONN_REASONS:postfix_smtp_lostconn_reason})?
 POSTFIX_SMTP_TIMEOUT %{POSTFIX_QUEUEID:postfix_queueid}: conversation with %{POSTFIX_RELAY_INFO} timed out( while %{POSTFIX_LOSTCONN_REASONS:postfix_smtp_lostconn_reason})?
-POSTFIX_SMTP_RELAYERR %{POSTFIX_QUEUEID:postfix_queueid}: host %{POSTFIX_RELAY_INFO} said: %{GREEDYDATA:postfix_smtp_response} \(in reply to %{POSTFIX_SMTP_STAGE:postfix_smtp_stage} command\)
+POSTFIX_SMTP_RELAYERR %{POSTFIX_QUEUEID:postfix_queueid}: host %{POSTFIX_RELAY_INFO} (said|refused to talk to me): %{GREEDYDATA:postfix_smtp_response}( \(in reply to %{POSTFIX_SMTP_STAGE:postfix_smtp_stage} command\))?
 POSTFIX_SMTP_SSLAUTHERR %{POSTFIX_QUEUEID:postfix_queueid}: SASL authentication failed; server %{POSTFIX_RELAY_INFO} said: %{GREEDYDATA:postfix_smtp_response}
 POSTFIX_SMTP_UTF8 host %{POSTFIX_RELAY_INFO} offers SMTPUTF8 support, but not 8BITMIME
 POSTFIX_SMTP_PIX %{POSTFIX_QUEUEID:postfix_queueid}: enabling PIX workarounds: %{DATA:postfix_pix_workaround} for %{POSTFIX_RELAY_INFO}
@@ -113,6 +113,9 @@ POSTFIX_BOUNCE_NOTIFICATION %{POSTFIX_QUEUEID:postfix_queueid}: sender (non-deli
 POSTFIX_SCACHE_LOOKUPS statistics: (address|domain) lookup hits=%{INT:postfix_scache_hits} miss=%{INT:postfix_scache_miss} success=%{INT:postfix_scache_success}%
 POSTFIX_SCACHE_SIMULTANEOUS statistics: max simultaneous domains=%{INT:postfix_scache_domains} addresses=%{INT:postfix_scache_addresses} connection=%{INT:postfix_scache_connection}
 POSTFIX_SCACHE_TIMESTAMP statistics: start interval %{SYSLOGTIMESTAMP:postfix_scache_timestamp}
+
+# verify patterns
+POSTFIX_VERIFY_CACHE cache %{DATA} (full|partial) cleanup: retained=%{NUMBER:postfix_verify_cache_retained} dropped=%{NUMBER:postfix_verify_cache_dropped} entries
 
 # aggregate all patterns
 POSTFIX_SMTPD %{POSTFIX_SMTPD_CONNECT}|%{POSTFIX_SMTPD_DISCONNECT}|%{POSTFIX_SMTPD_LOSTCONN}|%{POSTFIX_SMTPD_NOQUEUE}|%{POSTFIX_SMTPD_PIPELINING}|%{POSTFIX_TLSCONN}|%{POSTFIX_WARNING}|%{POSTFIX_SMTPD_PROXY}|%{POSTFIX_KEYVALUE}
@@ -140,3 +143,4 @@ POSTFIX_ERROR %{POSTFIX_ERROR_ANY}
 POSTFIX_POSTSUPER %{POSTFIX_POSTSUPER_ACTION}|%{POSTFIX_POSTSUPER_SUMMARY}
 POSTFIX_POSTMAP %{POSTFIX_WARNING}
 POSTFIX_SCRIPT %{POSTFIX_WARNING}
+POSTFIX_VERIFY %{POSTFIX_VERIFY_CACHE}


### PR DESCRIPTION
Grok pattern additions related to following log lines:

Sep 07 07:14:19 mail1 postfix/smtpd[40744]: disconnect from unknown[unknown] commands=0/0
Sep 07 07:17:39 mail1 postfix/anvil[40746]: statistics: max connection rate 1/60s for (smtp:unknown) at Sep  7 07:14:19
Aug 31 02:08:14 mail1 postfix/smtpd[34815]: lost connection after BDAT from bid47lw.transactional.hubspotemail.net[158.247.23.50]
Aug 31 02:08:14 mail1 postfix/smtpd[34815]: disconnect from bid47lw.transactional.hubspotemail.net[158.247.23.50] ehlo=2 starttls=1 mail=1 rcpt=0/1 bdat=0/1 commands=4/6
Aug 27 18:48:55 mail1 postfix/smtp[31995]: connect to mx1.FreeBSD.org[2610:1c1:1:606c::19:1]:25: Address not available
Aug 30 13:56:20 mail1 postfix/smtp[34352]: connect to mx.impressivevalue.com[52.8.227.207]:25: Operation timed out
Sep 25 15:33:04 mail1 postfix/smtp[9922]: 745137AA: lost connection with hotmail-com.olc.protection.outlook.com[104.47.55.161] while sending RCPT TO
Oct 21 05:35:02 mail1 postfix/smtpd[36291]: disconnect from unknown[93.188.162.137] ehlo=2 starttls=1 mail=1 rcpt=0/1 rset=1 noop=1 quit=1 commands=7/8
Nov 03 09:08:48 mail1 postfix/smtp[9862]: 840197AA: host mg2.egov.bg[213.91.191.86] refused to talk to me: 450 4.3.2 try again later
Aug 27 21:57:11 mail1 postfix/verify[32135]: cache lmdb:/var/lib/postfix/verify_cache full cleanup: retained=724 dropped=6 entries
Sep 26 03:41:14 mail1 postfix/verify[10346]: cache ??????????????????????????????????? partial cleanup: retained=1 dropped=0 entries
