### PR TITLE
Some warning messages have the queue-id after the warning level

### DIFF
--- a/postfix.grok
+++ b/postfix.grok
@@ -32,8 +32,8 @@ GREEDYDATA_NO_BRACKET [^<>]*
 STATUS_WORD [\w-]*
 
 # warning patterns
-POSTFIX_WARNING_WITH_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: (%{POSTFIX_CLIENT_INFO}: )?%{GREEDYDATA:postfix_message}; %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}
-POSTFIX_WARNING_WITHOUT_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: (%{POSTFIX_CLIENT_INFO}: )?%{GREEDYDATA:postfix_message}
+POSTFIX_WARNING_WITH_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: (%{POSTFIX_QUEUEID:postfix_queueid}: )?(%{POSTFIX_CLIENT_INFO}: )?%{GREEDYDATA:postfix_message}; %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}
+POSTFIX_WARNING_WITHOUT_KV (%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: (%{POSTFIX_QUEUEID:postfix_queueid}: )?(%{POSTFIX_CLIENT_INFO}: )?%{GREEDYDATA:postfix_message}
 POSTFIX_WARNING %{POSTFIX_WARNING_WITH_KV}|%{POSTFIX_WARNING_WITHOUT_KV}
 
 # smtpd patterns

--- a/test/cleanup_0012.yaml
+++ b/test/cleanup_0012.yaml
@@ -1,0 +1,6 @@
+pattern: ^%{POSTFIX_CLEANUP}$
+data: "warning: 9BECF3F19D: sender_canonical_maps map lookup problem for sender@example.com -- message not accepted, try again later"
+results:
+    postfix_queueid: 9BECF3F19D
+    postfix_message_level: warning
+    postfix_message: "sender_canonical_maps map lookup problem for sender@example.com -- message not accepted, try again later"


### PR DESCRIPTION
See https://github.com/whyscream/postfix-grok-patterns/issues/182