### PR TITLE
extended POSTFIX_TLSCONN for a higher smtpd_tls_loglevel

### DIFF
--- a/postfix.grok
+++ b/postfix.grok
@@ -23,7 +23,7 @@ POSTFIX_KEYVALUE %{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:pos
 POSTFIX_WARNING_LEVEL (warning|fatal|info)
 POSTFIX_VERIFY_CLEANUP_TYPE (full|partial)
 
-POSTFIX_TLSCONN (Anonymous|Trusted|Untrusted|Verified) TLS connection established (to %{POSTFIX_RELAY_INFO}|from %{POSTFIX_CLIENT_INFO}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \(%{DATA:postfix_tls_cipher_size} bits\)
+POSTFIX_TLSCONN (Anonymous|Trusted|Untrusted|Verified) TLS connection established (to %{POSTFIX_RELAY_INFO}|from %{POSTFIX_CLIENT_INFO}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \(%{DATA:postfix_tls_cipher_size} bits\)( key-exchange %{DATA:postfix_tls_key-exchange} server-signature %{DATA:postfix_tls_server-signature} \(%{DATA:postfix_tls_server-signature_size} bits\) server-digest %{DATA:postfix_tls_server-digest})?
 POSTFIX_TLSVERIFICATION certificate verification failed for %{POSTFIX_RELAY_INFO}: %{GREEDYDATA:postfix_tls_error}
 
 POSTFIX_DELAYS %{NUMBER:postfix_delay_before_qmgr}/%{NUMBER:postfix_delay_in_qmgr}/%{NUMBER:postfix_delay_conn_setup}/%{NUMBER:postfix_delay_transmission}

--- a/test/smtpd_0037.yaml
+++ b/test/smtpd_0037.yaml
@@ -1,0 +1,12 @@
+pattern: ^%{POSTFIX_SMTPD}$
+data: "Anonymous TLS connection established from julie.example.com[10.163.89.202]: TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange X25519 server-signature RSA-PSS (4096 bits) server-digest SHA256"
+results:
+    postfix_client_hostname: julie.example.com
+    postfix_client_ip: 10.163.89.202
+    postfix_tls_version: TLSv1.3
+    postfix_tls_cipher: TLS_AES_256_GCM_SHA384
+    postfix_tls_cipher_size: 256/256
+    postfix_tls_key-exchange: X25519 
+    postfix_tls_server-signature: RSA-PSS 
+    postfix_tls_server-signature_size: 4096
+    postfix_tls_server-digest: SHA256


### PR DESCRIPTION
Postfix 3.5.23 on a Debian 11.8 with [`smtpd_tls_loglevel`](https://www.postfix.org/postconf.5.html#smtpd_tls_loglevel) set to `1`.

Of course I noticed that the reason for the failed pattern was because I increased the default loglevel _after_ I had extended the pattern and added a test file. But maybe the extra data will help someone else too.

If not it might be an idea to have some `%{GREEDYDATA}` at the end of `POSTFIX_TLSCONN` so at least extended lines do not fail the basic pattern?