### PR TITLE
build logstash conf and ingest pipeline

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,3 @@
+tmp
+50-filter-postfix.conf
+pipeline.json

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,41 @@
+# Logstash config and Kibana Pipeline build script
+
+This script is used to generate a `50-filter-postfix.conf` file for Logstash and a corresponding `pipeline.json` to be used as an Ingest pipeline in Kibana.
+
+It was written to make it easier to keep the two environments similar when updating the patterns or configuration.
+
+One big issue with Kibana pipelines is that you'd have to upgrade the custom grok patterns in each processor individually. Adding the full set of `postfix.grok` patterns to each processor felt wrong too. So I tried to find a way that only adds the necessary patterns.
+
+The Ingest pipelines are also a little different than the Logstash filters. For example the grok processor does not remove fields or can set a tag on success.
+
+## Requirements
+- bash 4.0 to allow some modern string-variable handling
+- cut, grep, sed, cmp as general shell tools
+
+## Usage
+
+1. Run `bash splitpatterns.sh`. This will create a temporary folder and use some shell tool magic to loop through `../postfix.grok` recursively so it can create a file for each grok pattern that includes all its required subpatterns.
+2. Run `bash createconfigs.sh` to create the `50-filter-postfix.conf` and `pipeline.json` files.
+3. Use these files as needed
+
+
+## TODO
+- Should the `splitpatterns.sh` script be called from the `createconfigs.sh` instead of being run manually in advance? This would allow cleaning up the `tmp` folder too.
+- Document how to "load" and use the `pipeline.json` into Kibana in the main `README.md`. (see "Hints")
+- Make the scripts easier readable?
+- Convert IP fields?
+- Add processor to run a `whyscreem-postfix@custom` pipeline after if people want to mangle with the fields themselves (GeoIP referencing, renaming to local specifications, ...)?
+- Add a version number to the pipeline?
+- Find a way to set `_grok_postfix_program_nomatch` as a catchall tag for the pipeline. Without `else if` this might not be possible.
+- Move `postfix_client`, `postfix_relay` and `postfix_delays` out of the "kv" block. Pipelines don't allow this nesting?
+
+## Hints
+
+1. Load the `pipeline.json` file into elasticsearch:
+```
+curl -k -H "Content-Type: application/json" -T pipeline.json "/_ingest/pipeline/whyscream-postfix"
+```
+
+Additional parameters like `-H "Authorization: ApiKey ..." or `-u user:pass` might be needed just as protocol, hostname and port: `https://localhost:9200`.
+
+Then call this pipeline where needed.

--- a/build/createconfigs.sh
+++ b/build/createconfigs.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+
+function pipelinepatterns {
+    local tmpPatternComma=''
+    while IFS="" read -r line || [ -n "$line" ]; do
+        echo -ne "$tmpPatternComma"
+        echo -n "$line" |sed -E -e 's/([^ ]+) (.*)/        "\1": "\2"/' -e 's/\\/\\\\/g'
+        tmpPatternComma=",\n"
+    done < "tmp/$1"
+    echo
+}
+
+#####
+##### Intros
+#####
+
+cat > '50-filter-postfix.conf' << 'EOT'
+filter {
+    # grok log lines by program name (listed alpabetically)
+EOT
+
+cat > 'pipeline.json' << 'EOT'
+{
+  "processors": [
+EOT
+
+#####
+##### Groks for services
+#####
+
+tmpElse=''
+for service in anvil bounce cleanup dnsblog error local master pickup pipe postdrop postscreen qmgr scache sendmail smtp lmtp smtpd postsuper tlsmgr tlsproxy trivial-rewrite discard virtual postmap postfix-script verify
+do
+
+    # special handling for postfix-script: remove "postfix-"
+    serviceFixed="${service/postfix-/}"
+
+    serviceFixedUppercase="${serviceFixed^^}"
+
+cat >> '50-filter-postfix.conf' << EOT
+    ${tmpElse}if [program] =~ /^postfix.*\/${service}$/ {
+        grok {
+            patterns_dir   => "/etc/logstash/patterns.d"
+            match          => [ "message", "^%{POSTFIX_${serviceFixedUppercase//-/_}}$" ]
+            tag_on_failure => [ "_grok_postfix_${serviceFixed//-/_}_nomatch" ]
+            add_tag        => [ "_grok_postfix_success" ]
+        }
+EOT
+
+cat >> 'pipeline.json' << EOT
+  {
+    "grok": {
+      "field": "message",
+      "patterns": [
+        "^%{POSTFIX_${serviceFixedUppercase//-/_}}$"
+      ],
+      "pattern_definitions": {
+EOT
+
+pipelinepatterns "POSTFIX_${serviceFixedUppercase//-/_}.grok" >> 'pipeline.json'
+
+cat >> 'pipeline.json' << EOT
+      },
+      "ignore_missing": true,
+      "if": "ctx.process?.name != null && ctx.process.name.endsWith('/${service}')",
+      "description": "${serviceFixedUppercase}",
+      "on_failure": [
+        {
+          "append": {
+            "field": "tags",
+            "value": [
+              "_grokparsefailure",
+              "_grok_postfix_${serviceFixed}_nomatch"
+            ],
+            "allow_duplicates": false
+          }
+        }
+      ]
+    }
+  },
+EOT
+
+    tmpElse='} else '
+done
+
+#####
+##### Catchall tag
+#####
+
+# FIXME: Not sure how to do this in a Pipeline without `else if`
+
+cat >> '50-filter-postfix.conf' << 'EOT'
+    } else if [program] =~ /^postfix.*/ {
+        mutate {
+            add_tag => [ "_grok_postfix_program_nomatch" ]
+        }
+    }
+
+EOT
+
+
+#####
+##### KV handling
+#####
+
+cat >> '50-filter-postfix.conf' << 'EOT'
+    # process key-value data if it exists
+    if [postfix_keyvalue_data] {
+        kv {
+            source       => "postfix_keyvalue_data"
+            trim_value   => "<>,"
+            prefix       => "postfix_"
+            remove_field => [ "postfix_keyvalue_data" ]
+        }
+
+        # some post processing of key-value data
+EOT
+
+cat >> 'pipeline.json' << 'EOT'
+  {
+    "kv": {
+      "field": "postfix_keyvalue_data",
+      "field_split": " ",
+      "value_split": "=",
+      "ignore_missing": true,
+      "prefix": "postfix_",
+      "trim_value": "<>,"
+    }
+  },
+  {
+    "remove": {
+      "field": "postfix_keyvalue_data",
+      "ignore_missing": true
+    }
+  },
+EOT
+
+# FIXME these probably don't have to be inside of the KV `if` block,
+#       they can't be nested in a pipeline anyway
+
+tmpComma=''
+for field in postfix_client postfix_relay postfix_delays
+do
+cat >> '50-filter-postfix.conf' << EOT
+        if [${field}] {
+            grok {
+                patterns_dir   => "/etc/logstash/patterns.d"
+                match          => ["${field}", "^%{${field^^}}$"]
+                tag_on_failure => [ "_grok_kv_${field}_nomatch" ]
+                remove_field   => [ "${field}" ]
+            }
+        }
+EOT
+
+    echo -e "${tmpComma}  {" >> 'pipeline.json'
+cat >> 'pipeline.json' << EOT
+    "grok": {
+      "field": "${field}",
+      "patterns": [
+        "^%{${field^^}}$"
+      ],
+      "pattern_definitions": {
+EOT
+    pipelinepatterns "${field^^}.grok" >> 'pipeline.json'
+cat >> 'pipeline.json' << EOT
+      },
+      "ignore_missing": true,
+      "description": "${field}",
+      "on_failure": [
+        {
+          "append": {
+            "field": "tags",
+            "value": [
+              "_grok_kv_${field}_nomatch"
+            ],
+            "allow_duplicates": false
+          }
+        }
+      ]
+    }
+  },
+  {
+    "remove": {
+      "field": "${field}",
+      "ignore_missing": true,
+      "if": "ctx?.tags?.contains('_grok_kv_${field}_nomatch')==false",
+      "description": "${field}"
+    }
+  },
+EOT
+
+done
+
+cat >> '50-filter-postfix.conf' << EOT
+    }
+
+    # process command counter data if it exists
+EOT
+
+# FIXME this could be included in the above list if that wasn't nested
+# but this would require changes in the tags field
+field='postfix_command_counter_data'
+cat >> '50-filter-postfix.conf' << EOT
+    if [${field}] {
+        grok {
+            patterns_dir   => "/etc/logstash/patterns.d"
+            match          => ["${field}", "^%{${field^^}}$"]
+            tag_on_failure => ["_grok_${field}_nomatch"]
+            remove_field   => ["${field}"]
+        }
+    }
+
+EOT
+
+cat >> 'pipeline.json' << EOT
+  {
+    "grok": {
+      "field": "${field}",
+      "patterns": [
+        "^%{${field^^}}$"
+      ],
+      "pattern_definitions": {
+EOT
+    pipelinepatterns "${field^^}.grok" >> 'pipeline.json'
+cat >> 'pipeline.json' << EOT
+      },
+      "ignore_missing": true,
+      "description": "${field}",
+      "on_failure": [
+        {
+          "append": {
+            "field": "tags",
+            "value": [
+              "_grok_${field}_nomatch"
+            ],
+            "allow_duplicates": false
+          }
+        }
+      ]
+    }
+  },
+  {
+    "remove": {
+      "field": "${field}",
+      "ignore_missing": true,
+      "if": "ctx?.tags?.contains('_grok_${field}_nomatch')==false",
+      "description": "${field}"
+    }
+  },
+EOT
+
+#####
+##### Conversions
+#####
+
+cat >> '50-filter-postfix.conf' << 'EOT'
+    # Do some data type conversions
+    mutate {
+        convert => [
+            # list of integer fields
+EOT
+
+##### Integer fields
+
+tmpComma=''
+for field in anvil_cache_size anvil_conn_count anvil_conn_rate client_port cmd_auth cmd_auth_accepted cmd_bdat cmd_bdat_accepted cmd_count cmd_count_accepted cmd_data cmd_data_accepted cmd_ehlo cmd_ehlo_accepted cmd_helo cmd_helo_accepted cmd_mail cmd_mail_accepted cmd_noop cmd_noop_accepted cmd_quit cmd_quit_accepted cmd_rcpt cmd_rcpt_accepted cmd_rset cmd_rset_accepted cmd_starttls cmd_starttls_accepted cmd_unknown cmd_unknown_accepted nrcpt postscreen_cache_dropped postscreen_cache_retained postscreen_dnsbl_rank relay_port server_port size status_code termination_signal tls_server_signature_size verify_cache_dropped verify_cache_retained
+do
+    echo -ne "${tmpComma}            \"postfix_${field}\", \"integer\"" >> '50-filter-postfix.conf'
+
+    echo -e "${tmpComma}  {" >> 'pipeline.json'
+cat >> 'pipeline.json' << EOT
+    "convert": {
+      "field": "postfix_${field}",
+      "type": "integer",
+      "ignore_missing": true
+    }
+EOT
+    echo -n "  }" >> 'pipeline.json'
+
+    tmpComma=",\n"
+done
+
+echo -e "$tmpComma\n            # list of float fields" >> '50-filter-postfix.conf'
+echo -ne "$tmpComma" >> 'pipeline.json'
+
+##### Float fields
+
+tmpComma=''
+for field in delay delay_before_qmgr delay_conn_setup delay_in_qmgr delay_transmission postscreen_violation_time
+do
+    echo -ne "${tmpComma}            \"postfix_${field}\", \"float\"" >> '50-filter-postfix.conf'
+
+    echo -e "${tmpComma}  {" >> 'pipeline.json'
+cat >> 'pipeline.json' << EOT
+    "convert": {
+      "field": "postfix_${field}",
+      "type": "float",
+      "ignore_missing": true
+    }
+EOT
+    echo -n "  }" >> 'pipeline.json'
+
+    tmpComma=",\n"
+done
+
+##### Outros
+
+cat >> '50-filter-postfix.conf' << 'EOT'
+
+        ]
+    }
+}
+
+EOT
+
+echo  -e "\n]\n}" >> 'pipeline.json'

--- a/build/createconfigs.sh
+++ b/build/createconfigs.sh
@@ -183,7 +183,7 @@ cat >> 'pipeline.json' << EOT
     "remove": {
       "field": "${field}",
       "ignore_missing": true,
-      "if": "ctx?.tags?.contains('_grok_kv_${field}_nomatch')==false",
+      "if": "ctx?.tags==null || ctx?.tags?.contains('_grok_kv_${field}_nomatch')==false",
       "description": "${field}"
     }
   },
@@ -243,7 +243,7 @@ cat >> 'pipeline.json' << EOT
     "remove": {
       "field": "${field}",
       "ignore_missing": true,
-      "if": "ctx?.tags?.contains('_grok_${field}_nomatch')==false",
+      "if": "ctx?.tags==null || ctx?.tags?.contains('_grok_${field}_nomatch')==false",
       "description": "${field}"
     }
   },

--- a/build/splitPatterns.sh
+++ b/build/splitPatterns.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# needs bash 4.0, cut, grep, sed, cmp
+
+# setup
+mkdir -p tmp
+rm tmp/*
+
+# loop through all patterns in postfix.grok
+while IFS="" read -r line || [ -n "$line" ]
+do
+    # skip empty and comment lines
+    if [[ "$line" == "" || "${line:0:1}" == "#" ]]; then continue; fi
+
+    # cut the name of the pattern
+    name=$(echo "$line" | cut -d ' ' -f 1)
+
+    echo "Finding patterns for $name"
+
+    echo "$line" > "tmp/patterns.tmp"
+
+    # loop until all required patterns are found
+    while true
+    do
+
+        # loop through all patterns that were found so far in patterns.tmp
+        while IFS="" read -r pattern || [ -n "$pattern" ]
+        do
+
+            # search for %{} placeholder in each line and add its pattern to morePatterns.tmp
+            while IFS="" read -r placeholder || [ -n "$placeholder" ]
+            do
+                grep -E "^$placeholder " "../postfix.grok" >> "tmp/morePatterns.tmp"
+            done <<< $( echo "${pattern}" | grep -oE '%{[^:}]+(:[^}]+)?}' | sed -E 's/^%{([^:}]+)(:.*)?}/\1/' )
+
+        done < "tmp/patterns.tmp"
+
+        # combine patterns.tmp and morePatterns.tmp, remove duplicate lines
+        cat tmp/patterns.tmp tmp/morePatterns.tmp |sort |uniq > tmp/combinedPatterns.tmp
+
+        # if patterns.tmp and combinedPatterns.tmp are equal we've found all patterns
+        if cmp --silent -- "tmp/patterns.tmp" "tmp/combinedPatterns.tmp"; then
+           rm tmp/morePatterns.tmp tmp/combinedPatterns.tmp
+           break
+        fi
+
+        # run once again with the updated set of found patterns
+        mv tmp/combinedPatterns.tmp tmp/patterns.tmp
+        rm tmp/morePatterns.tmp
+
+    done
+
+    # rename pattern file to actual name of the pattern
+    mv tmp/patterns.tmp "tmp/${name}.grok"
+
+done < "../postfix.grok"


### PR DESCRIPTION
0.0 beta - first revision to see what you think of this.

# Logstash config and Kibana Pipeline build script

This script is used to generate a `50-filter-postfix.conf` file for Logstash and a corresponding `pipeline.json` to be used as an Ingest pipeline in Kibana.

It was written to make it easier to keep the two environments similar when updating the patterns or configuration.

One big issue with Kibana pipelines is that you'd have to upgrade the custom grok patterns in each processor individually. Adding the full set of `postfix.grok` patterns to each processor felt wrong too. So I tried to find a way that only adds the necessary patterns.

The Ingest pipelines are also a little different than the Logstash filters. For example the grok processor does not remove fields or can set a tag on success.

## Requirements
- bash 4.0 to allow some modern string-variable handling
- cut, grep, sed, cmp as general shell tools

## Usage

1. Run `bash splitpatterns.sh`. This will create a temporary folder and use some shell tool magic to loop through `../postfix.grok` recursively so it can create a file for each grok pattern that includes all its required subpatterns.
2. Run `bash createconfigs.sh` to create the `50-filter-postfix.conf` and `pipeline.json` files.
3. Use these files as needed


## TODO
- Should the `splitpatterns.sh` script be called from the `createconfigs.sh` instead of being run manually in advance? This would allow cleaning up the `tmp` folder too.
- Document how to "load" and use the `pipeline.json` into Kibana in the main `README.md`. (see "Hints")
- Make the scripts easier readable?
- Convert IP fields?
- Add processor to run a `whyscreem-postfix@custom` pipeline after if people want to mangle with the fields themselves (GeoIP referencing, renaming to local specifications, ...)?
- Add a version number to the pipeline?
- Find a way to set `_grok_postfix_program_nomatch` as a catchall tag for the pipeline. Without `else if` this might not be possible.
- Move `postfix_client`, `postfix_relay` and `postfix_delays` out of the "kv" block. Pipelines don't allow this nesting?

## Hints

1. Load the `pipeline.json` file into elasticsearch:
```
curl -k -H "Content-Type: application/json" -T pipeline.json "/_ingest/pipeline/whyscream-postfix"
```

Additional parameters like `-H "Authorization: ApiKey ..."` or `-u user:pass` might be needed just as protocol, hostname and port: `https://localhost:9200`.

Then call this pipeline where needed.