### PR TITLE
Extract the elliptic curve name from TLS connection lines

### DIFF
--- a/postfix.grok
+++ b/postfix.grok
@@ -4,6 +4,7 @@ GREEDYDATA_NO_SEMICOLON [^;]*
 GREEDYDATA_NO_BRACKET [^<>]*
 STATUS_WORD [\w-]*
 IP_UNKNOWN unknown
+CURVE_WORD [PBK]-[0-9]+
 
 # common postfix patterns
 POSTFIX_QUEUEID ([0-9A-F]{6,}|[0-9a-zA-Z]{12,}|NOQUEUE)
@@ -24,7 +25,7 @@ POSTFIX_WARNING_LEVEL (warning|fatal|info)
 POSTFIX_VERIFY_CLEANUP_TYPE (full|partial)
 
 
-POSTFIX_TLSCONN %{DATA:postfix_tls_trustlevel} TLS connection established (to %{POSTFIX_RELAY}|from %{POSTFIX_CLIENT}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \(%{DATA:postfix_tls_cipher_size} bits\)( key-exchange %{DATA:postfix_tls_key_exchange} server-signature %{DATA:postfix_tls_server_signature} \(%{DATA:postfix_tls_server_signature_size} bits\) server-digest %{DATA:postfix_tls_server_digest})?
+POSTFIX_TLSCONN %{DATA:postfix_tls_trustlevel} TLS connection established (to %{POSTFIX_RELAY}|from %{POSTFIX_CLIENT}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \(%{DATA:postfix_tls_cipher_size} bits\)( key-exchange %{DATA:postfix_tls_key_exchange} server-signature %{DATA:postfix_tls_server_signature} \((%{INT:postfix_tls_server_signature_size} bits|%{CURVE_WORD:postfix_tls_server_signature_curve})\) server-digest %{DATA:postfix_tls_server_digest})?
 POSTFIX_TLSVERIFICATION certificate verification failed for %{POSTFIX_RELAY}: %{GREEDYDATA:postfix_tls_error}
 
 POSTFIX_DELAYS %{NUMBER:postfix_delay_before_qmgr}/%{NUMBER:postfix_delay_in_qmgr}/%{NUMBER:postfix_delay_conn_setup}/%{NUMBER:postfix_delay_transmission}

--- a/test/smtp_0035.yaml
+++ b/test/smtp_0035.yaml
@@ -1,0 +1,14 @@
+pattern: ^%{POSTFIX_SMTP}$
+data: "Untrusted TLS connection established to gmail-smtp-in.l.google.com[74.125.128.27]:25: TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange X25519 server-signature ECDSA (P-256) server-digest SHA256"
+results:
+    postfix_tls_trustlevel: Untrusted
+    postfix_relay_hostname: gmail-smtp-in.l.google.com
+    postfix_relay_ip: 74.125.128.27
+    postfix_relay_port: 25
+    postfix_tls_version: TLSv1.3
+    postfix_tls_cipher: TLS_AES_256_GCM_SHA384
+    postfix_tls_cipher_size: 256/256
+    postfix_tls_key_exchange: X25519
+    postfix_tls_server_signature: ECDSA
+    postfix_tls_server_signature_curve: P-256
+    postfix_tls_server_digest: SHA256


### PR DESCRIPTION
For TLS connections that don't report the amount of bits for the server signature but an elliptic curve, extract that information. 

Resolves #197 