### PR TITLE
add TLS connection line with missing server-digest

### DIFF
--- a/postfix.grok
+++ b/postfix.grok
@@ -21,7 +21,7 @@ POSTFIX_KEYVALUE_DATA [\w-]+=[^;]*
 POSTFIX_KEYVALUE %{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}
 
 
-POSTFIX_TLSCONN %{DATA:postfix_tls_trustlevel} TLS connection established (to %{POSTFIX_RELAY}|from %{POSTFIX_CLIENT}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \(%{DATA:postfix_tls_cipher_size} bits\)( key-exchange %{DATA:postfix_tls_key_exchange} server-signature %{DATA:postfix_tls_server_signature} \((%{INT:postfix_tls_server_signature_size} bits|(?<postfix_tls_server_signature_curve>[PBK]-\d+))\) server-digest %{DATA:postfix_tls_server_digest})?
+POSTFIX_TLSCONN %{DATA:postfix_tls_trustlevel} TLS connection established (to %{POSTFIX_RELAY}|from %{POSTFIX_CLIENT}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \(%{DATA:postfix_tls_cipher_size} bits\)( key-exchange %{DATA:postfix_tls_key_exchange} server-signature %{DATA:postfix_tls_server_signature} \((%{INT:postfix_tls_server_signature_size} bits|(?<postfix_tls_server_signature_curve>[PBK]-\d+))\)( server-digest %{DATA:postfix_tls_server_digest})?)?
 POSTFIX_TLSVERIFICATION certificate verification failed for %{POSTFIX_RELAY}: %{GREEDYDATA:postfix_tls_error}
 
 POSTFIX_DELAYS %{NUMBER:postfix_delay_before_qmgr}/%{NUMBER:postfix_delay_in_qmgr}/%{NUMBER:postfix_delay_conn_setup}/%{NUMBER:postfix_delay_transmission}

--- a/test/smtp_0036.yaml
+++ b/test/smtp_0036.yaml
@@ -1,0 +1,13 @@
+pattern: ^%{POSTFIX_SMTP}$
+data: "Trusted TLS connection established to mail.example.com[127.0.0.1]:25: TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange X25519 server-signature RSA-PSS (4096 bits)"
+results:
+    postfix_tls_trustlevel: Trusted
+    postfix_relay_hostname: mail.example.com
+    postfix_relay_ip: 127.0.0.1
+    postfix_relay_port: 25
+    postfix_tls_version: TLSv1.3
+    postfix_tls_cipher: TLS_AES_256_GCM_SHA384
+    postfix_tls_cipher_size: 256/256
+    postfix_tls_key_exchange: X25519
+    postfix_tls_server_signature: RSA-PSS
+    postfix_tls_server_signature_size: 4096


### PR DESCRIPTION
If there is a line missing `server-digest SHA256` in the end,  `postfix_tls_cipher_size` will be set to `256/256 bits) key-exchange X25519 server-signature RSA-PSS (4096`.

This fixes that by making it optional.